### PR TITLE
Separating GET and POST requests

### DIFF
--- a/src/GGDX/PhpInsightly/InsightlyRequest.php
+++ b/src/GGDX/PhpInsightly/InsightlyRequest.php
@@ -136,29 +136,29 @@ class InsightlyRequest{
         ]);
         try {
             switch ($method) {
-                case in_array($method, ['GET','POST']):
-                    if(count($data)){
-                        $response = $client->request($method,$url.'?'.http_build_query($data));
-                    } else {
-                        $response = $client->request($method,$url);
-                    }
-                    break;
-                // case 'GET':
+                // case in_array($method, ['GET','POST']):
                 //     if(count($data)){
                 //         $response = $client->request($method,$url.'?'.http_build_query($data));
                 //     } else {
                 //         $response = $client->request($method,$url);
                 //     }
                 //     break;
-                // case 'POST':
-                //     if(count($data)){
-                //         $response = $client->request($method,$url,[
-                //             'body' => $data,
-                //         ]);
-                //     } else {
-                //         $response = $client->request($method,$url);
-                //     }
-                //     break;
+                case 'GET':
+                    if(count($data)){
+                        $response = $client->request($method,$url.'?'.http_build_query($data));
+                    } else {
+                        $response = $client->request($method,$url);
+                    }
+                    break;
+                case 'POST':
+                    if(count($data)){
+                        $response = $client->request($method,$url,[
+                            'form_params' => $data,
+                        ]);
+                    } else {
+                        $response = $client->request($method,$url);
+                    }
+                    break;
                 case 'PUT':
                     $response = $client->request('PUT',$url, ['json' => $data]);
                     break;

--- a/src/GGDX/PhpInsightly/InsightlyRequest.php
+++ b/src/GGDX/PhpInsightly/InsightlyRequest.php
@@ -136,13 +136,6 @@ class InsightlyRequest{
         ]);
         try {
             switch ($method) {
-                // case in_array($method, ['GET','POST']):
-                //     if(count($data)){
-                //         $response = $client->request($method,$url.'?'.http_build_query($data));
-                //     } else {
-                //         $response = $client->request($method,$url);
-                //     }
-                //     break;
                 case 'GET':
                     if(count($data)){
                         $response = $client->request($method,$url.'?'.http_build_query($data));

--- a/src/GGDX/PhpInsightly/InsightlyRequest.php
+++ b/src/GGDX/PhpInsightly/InsightlyRequest.php
@@ -143,6 +143,22 @@ class InsightlyRequest{
                         $response = $client->request($method,$url);
                     }
                     break;
+                // case 'GET':
+                //     if(count($data)){
+                //         $response = $client->request($method,$url.'?'.http_build_query($data));
+                //     } else {
+                //         $response = $client->request($method,$url);
+                //     }
+                //     break;
+                // case 'POST':
+                //     if(count($data)){
+                //         $response = $client->request($method,$url,[
+                //             'body' => $data,
+                //         ]);
+                //     } else {
+                //         $response = $client->request($method,$url);
+                //     }
+                //     break;
                 case 'PUT':
                     $response = $client->request('PUT',$url, ['json' => $data]);
                     break;


### PR DESCRIPTION
For some reason, posting data as query string did not work for creating new Insightly Events.