### PR TITLE
Make PUT requests use PUT method

### DIFF
--- a/src/GGDX/PhpInsightly/InsightlyRequest.php
+++ b/src/GGDX/PhpInsightly/InsightlyRequest.php
@@ -78,7 +78,7 @@ class InsightlyRequest{
     public function put($url, array $data = [])
     {
         $data = $this->sanitizeBools($data);
-        return $this->request(self::REQ_POST,$url, $data);
+        return $this->request(self::REQ_PUT,$url, $data);
     }
 
 


### PR DESCRIPTION
Some update methods (for ex., updateOrganisationCustomField) requires PUT request instead of POST.