### PR TITLE
Fix POST (creation) requests

### DIFF
--- a/src/GGDX/PhpInsightly/InsightlyRequest.php
+++ b/src/GGDX/PhpInsightly/InsightlyRequest.php
@@ -136,15 +136,20 @@ class InsightlyRequest{
         ]);
         try {
             switch ($method) {
-                case in_array($method, ['GET','POST']):
+                case 'GET':
                     if(count($data)){
                         $response = $client->request($method,$url.'?'.http_build_query($data));
                     } else {
                         $response = $client->request($method,$url);
                     }
                     break;
+                case 'POST':
                 case 'PUT':
-                    $response = $client->request('PUT',$url, ['json' => $data]);
+                    if(count($data)){
+                        $response = $client->request($method,$url, ['json' => $data]);
+                    } else {
+                        $response = $client->request($method,$url);
+                    }
                     break;
                 default:
                     $request = new Request($method, $url);


### PR DESCRIPTION
POST requests where not sending data as JSON but as query-string parameters instead.

I'm not aware of POST requests which need parameters passed via GET, so I have made post behave in same way as PUT request. If there are such, please let me know and I will try to implement two types of POST (or extend existing request).

This allows to create new entities (like contacts for ex.) on Insightly side.